### PR TITLE
Fix the -conf parameter handling

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -1068,18 +1068,8 @@ const boost::filesystem::path &GetDataDir(bool fNetSpecific)
 
 boost::filesystem::path GetConfigFile()
 {
-/*	boost::filesystem::path pathConfigFile(GetArg("-conf", "vpncoin.conf"));
+    boost::filesystem::path pathConfigFile(GetArg("-conf", "vpncoin.conf"));
     if (!pathConfigFile.is_complete()) pathConfigFile = GetDataDir(false) / pathConfigFile;
-    return pathConfigFile; */
-	
-    string sConf = GetArg("-conf", "vpncoin.conf");
-	boost::filesystem::path pathConfigFile = boost::filesystem::current_path() / sConf;
-	
-    boost::filesystem::ifstream streamConfig( pathConfigFile );
-    if (!streamConfig.good())	// No vpncoin.conf file is OK	
-	{
-		pathConfigFile = GetDataDir(false) / sConf;
-	}
     return pathConfigFile;
 }
 


### PR DESCRIPTION
We currently run the VPNcoin daemon with the following parameters:

-datadir=/path/to/data -conf=/path/to/coind.conf

However with the latest code broke our deployment as it looks the
configuration file in the following invalid location:

/path/to/data/path/to/coind.conf